### PR TITLE
Outputs for policy ARNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ module "iam" {
 | resource_admin_group_arn | The ARN of the resource-admin IAM group |
 | deployer_admin_group_arn | The ARN of the deployer-admin IAM group |
 | read_only_group_arn | The ARN of the read-only IAM group |
+| full_admin_policy_arn | The ARN of the full-admin IAM policy |
+| iam_admin_policy_arn | The ARN of the iam-admin IAM policy |
+| partial_admin_policy_arn | The ARN of the partial-admin IAM policy |
+| require_mfa_policy_arn | The ARN of the require-mfa IAM policy |
 | full_admin_role_arn | The ARN of the full-admin IAM role (requires saml_provider_arn) |
 | ops_admin_role_arn | The ARN of the ops-admin IAM role (requires saml_provider_arn) |
 | resource_admin_role_arn | The ARN of the resource-admin IAM role (requires saml_provider_arn) |

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,6 +14,19 @@ output "ready_only_group_arn" {
   value = aws_iam_group.read_only.arn
 }
 
+output "full_admin_policy_arn" {
+  value = aws_iam_policy.full_admin.arn
+}
+output "iam_admin_policy_arn" {
+  value = aws_iam_policy.iam_admin.arn
+}
+output "partial_admin_policy_arn" {
+  value = aws_iam_policy.partial_admin.arn
+}
+output "require_mfa_policy_arn" {
+  value = aws_iam_policy.require_mfa.arn
+}
+
 output "full_admin_role_arn" {
   value = length(var.saml_provider_arn) > 0 ? aws_iam_role.full_admin[0].arn : ""
 }


### PR DESCRIPTION
https://github.com/18F/aws-admin/pull/172

In some cases, you might be more interested in composing the policies to other
roles/groups. Specifically, the require-mfa policy is useful for any IAM groups
with humans. Using outputs allows Terraform to infer dependencies.

In our case, we have code like this, but with outputs we can remove the data
source and explicit dependency.

```terraform
data "aws_iam_policy" "require_mfa" {
  name = "require-mfa"

  # require-mfa is created by grace-iam
  depends_on = [module.grace_iam]
}
```
