### PR TITLE
Make IAM group creation optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Control    | CSP/AWS | HOST/OS | App/DB | How is it implemented?
 
 ### Groups
 
+These groups are created by default. You can set `create_iam_groups = false` to
+prevent the creation of these groups.
+
 |Name|Policies|
 |----|-------|
 | full-admin | `full-admin` `require-mfa` |
@@ -96,6 +99,7 @@ module "iam" {
 |------|-------------|:----:|:-----:|:-----:|
 | saml_provider_arn | The AWS Resource Name (ARN) for the Security Assertion Markup Language (SAML) provider | string | "" | no |
 | allowed_regions | A list of the allowed regions | list | us-east-1, us-west-1 | no |
+| create_iam_groups | the boolean value indicating whether to create IAM groups | bool | true | no |
 | password_policy_min_length | the number representing the minimum password length | number | 16 | no |
 | password_policy_require_uppercase | the boolean value indicating whether to require uppercase characters in passwords | bool | true | no |
 | password_policy_require_lowercase | the boolean value indicating whether to require lowercase characters in passwords | bool | true | no |

--- a/groups.tf
+++ b/groups.tf
@@ -4,79 +4,107 @@
 
 # full-admin group
 resource "aws_iam_group" "full_admin" {
+  count = var.create_iam_groups ? 1 : 0
+
   name = "full-admin"
 }
 
 # attach full-admin policy to full-admin group
 resource "aws_iam_group_policy_attachment" "full_admin" {
-  group      = aws_iam_group.full_admin.name
+  count = var.create_iam_groups ? 1 : 0
+
+  group      = aws_iam_group.full_admin[0].name
   policy_arn = aws_iam_policy.full_admin.arn
 }
 
 # attach require-mfa policy to full-admin group
 resource "aws_iam_group_policy_attachment" "full_admin_mfa" {
-  group      = aws_iam_group.full_admin.name
+  count = var.create_iam_groups ? 1 : 0
+
+  group      = aws_iam_group.full_admin[0].name
   policy_arn = aws_iam_policy.require_mfa.arn
 }
 
 # ops-admin group
 resource "aws_iam_group" "ops_admin" {
+  count = var.create_iam_groups ? 1 : 0
+
   name = "ops-admin"
 }
 
 # attach partial-admin policy to ops-admin group
 resource "aws_iam_group_policy_attachment" "ops_admin" {
-  group      = aws_iam_group.ops_admin.name
+  count = var.create_iam_groups ? 1 : 0
+
+  group      = aws_iam_group.ops_admin[0].name
   policy_arn = aws_iam_policy.partial_admin.arn
 }
 
 # attach iam-admin policy to ops-admin group
 resource "aws_iam_group_policy_attachment" "ops_admin_iam" {
-  group      = aws_iam_group.ops_admin.name
+  count = var.create_iam_groups ? 1 : 0
+
+  group      = aws_iam_group.ops_admin[0].name
   policy_arn = aws_iam_policy.iam_admin.arn
 }
 
 # attach require-mfa policy to ops-admin group
 resource "aws_iam_group_policy_attachment" "ops_admin_mfa" {
-  group      = aws_iam_group.ops_admin.name
+  count = var.create_iam_groups ? 1 : 0
+
+  group      = aws_iam_group.ops_admin[0].name
   policy_arn = aws_iam_policy.require_mfa.arn
 }
 
 # resource-admin group
 resource "aws_iam_group" "resource_admin" {
+  count = var.create_iam_groups ? 1 : 0
+
   name = "resource-admin"
 }
 
 # attach partial-admin policy to resource-admin group
 resource "aws_iam_group_policy_attachment" "resource_admin" {
-  group      = aws_iam_group.resource_admin.name
+  count = var.create_iam_groups ? 1 : 0
+
+  group      = aws_iam_group.resource_admin[0].name
   policy_arn = aws_iam_policy.partial_admin.arn
 }
 
 # attach require-mfa policy to resource-admin group
 resource "aws_iam_group_policy_attachment" "resource_admin_mfa" {
-  group      = aws_iam_group.resource_admin.name
+  count = var.create_iam_groups ? 1 : 0
+
+  group      = aws_iam_group.resource_admin[0].name
   policy_arn = aws_iam_policy.require_mfa.arn
 }
 
 # deployer-admin group
 resource "aws_iam_group" "deployer_admin" {
+  count = var.create_iam_groups ? 1 : 0
+
   name = "deployer-admin"
 }
 
 # attach full-admin policy to deployer-admin group
 resource "aws_iam_group_policy_attachment" "deployer_admin" {
-  group      = aws_iam_group.deployer_admin.name
+  count = var.create_iam_groups ? 1 : 0
+
+  group      = aws_iam_group.deployer_admin[0].name
   policy_arn = aws_iam_policy.full_admin.arn
 }
 
 # read-only group
 resource "aws_iam_group" "read_only" {
+  count = var.create_iam_groups ? 1 : 0
+
   name = "read-only"
 }
 
 # attach ReadOnlyAccess policy to read-only group
 resource "aws_iam_group_policy_attachment" "read_only" {
-  group      = aws_iam_group.read_only.name
+  count = var.create_iam_groups ? 1 : 0
+
+  group      = aws_iam_group.read_only[0].name
   policy_arn = data.aws_iam_policy.read_only.arn
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,17 +1,17 @@
 output "full_admin_group_arn" {
-  value = aws_iam_group.full_admin.arn
+  value = var.create_iam_groups ? aws_iam_group.full_admin[0].arn : ""
 }
 output "ops_admin_group_arn" {
-  value = aws_iam_group.ops_admin.arn
+  value = var.create_iam_groups ? aws_iam_group.ops_admin[0].arn : ""
 }
 output "resource_admin_group_arn" {
-  value = aws_iam_group.resource_admin.arn
+  value = var.create_iam_groups ? aws_iam_group.resource_admin[0].arn : ""
 }
 output "deployer_admin_group_arn" {
-  value = aws_iam_group.deployer_admin.arn
+  value = var.create_iam_groups ? aws_iam_group.deployer_admin[0].arn : ""
 }
 output "ready_only_group_arn" {
-  value = aws_iam_group.read_only.arn
+  value = var.create_iam_groups ? aws_iam_group.read_only[0].arn : ""
 }
 
 output "full_admin_role_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "allowed_regions" {
   default     = ["us-east-1", "us-west-1"]
 }
 
+variable "create_iam_groups" {
+  type        = bool
+  description = "(optional) the boolean value indicating whether to create IAM groups"
+  default     = true
+}
+
 variable "password_policy_min_length" {
   type        = number
   description = "(optional) the number representing the minimum password length"


### PR DESCRIPTION
https://github.com/18F/aws-admin/pull/172

Add a variable to make creation of the IAM groups optional, defaulting to true
to preserve the behavior.

In situations where using AssumeRole or defining IAM groups with least
privilege, having the default groups here is unnecessary and can even be
confusing when trying to figure out which admin group is the "right" one.
